### PR TITLE
Add ability to re-generate invitation URLs

### DIFF
--- a/app/assets/stylesheets/utils/_base.scss
+++ b/app/assets/stylesheets/utils/_base.scss
@@ -1,4 +1,5 @@
 //= require utils/_border
+//= require utils/_icon
 //= require utils/_sizing
 //= require utils/_spacing
 //= require utils/_typography

--- a/app/assets/stylesheets/utils/_icon.scss
+++ b/app/assets/stylesheets/utils/_icon.scss
@@ -1,0 +1,4 @@
+.icon-15 svg {
+  height: 15px;
+  width: 15px;
+}

--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -8,4 +8,21 @@
       <%= user.member_status_text %>
     </span>
   </td>
+
+  <td>
+    <% if user.pending? %>
+      <%= form_for(
+        user,
+        as: :user,
+        url: invitation_path(:user),
+        html: { method: :post }
+      ) do |f| %>
+        <%= f.hidden_field(:email, value: f.object.email) %>
+        <%= button_tag(class: "btn btn-link btn-sm icon-15", title: "Invitation Link",
+          type: "submit") do %>
+          <i data-feather="mail"></i>
+        <% end %>
+      <% end %>
+    <% end %>
+  </td>
 </tr>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -25,6 +25,7 @@
                 <th><%= t('.email') %></th>
                 <th><%= t('.created_on') %></th>
                 <th><%= t('.status') %></th>
+                <th></th>
               </tr>
             </thead>
             <tbody>

--- a/config/locales/devise_invitable.en.yml
+++ b/config/locales/devise_invitable.en.yml
@@ -3,7 +3,6 @@ en:
     failure:
       invited: "You have a pending invitation, accept it to finish creating your account."
     invitations:
-      send_instructions: "An invitation email has been sent to %{email}."
       invitation_token_invalid: "The invitation token provided is not valid!"
       updated: "Welcome to Storm, your easy-to-use self-hosted monitoring service!"
       updated_not_active: "Your password was set successfully."


### PR DESCRIPTION
Since Storm does not send emails, users could forget their invitation
links, which prevents them from accessing the system.

This PR allows the logged in user to re-generate that invitation URL to
give to the user.