### PR TITLE
Fix column width

### DIFF
--- a/app/views/users/_user.html.erb
+++ b/app/views/users/_user.html.erb
@@ -9,7 +9,7 @@
     </span>
   </td>
 
-  <td>
+  <td class="text-right">
     <% if user.pending? %>
       <%= form_for(
         user,

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -4,7 +4,7 @@
 </div>
 
 <div class="row">
-  <div class="col-sm-4 offset-sm-4">
+  <div class="col-md-4 offset-md-4">
     <%= link_to(new_user_invitation_path,
       class: "card card-link mb-3") do %>
       <div class="card-body text-muted text-center d-flex align-items-center justify-content-center">
@@ -16,7 +16,7 @@
 </div>
 
 <div class="row justify-content-center">
-  <div class="col-md-8">
+  <div class="col-lg-8">
     <div class="card card-body mb-3">
       <div class="table-responsive">
         <table class="table table-border-around mb-0">
@@ -25,7 +25,7 @@
               <th><%= t('.email') %></th>
               <th><%= t('.created_on') %></th>
               <th><%= t('.status') %></th>
-              <th></th>
+              <th style="min-width: 140px;"></th>
             </tr>
           </thead>
           <tbody>


### PR DESCRIPTION
Actionable icons in the table were blocking to the next row on certain screen widths. This PR makes sure they stay inline.

---

| Before | After |
| ------ | ---- |
| <img width="205" alt="screen shot 2018-06-23 at 12 22 39 pm" src="https://user-images.githubusercontent.com/3933204/41812240-04a71580-76e5-11e8-8f72-c0be14929f5b.png"> | <img width="234" alt="screen shot 2018-06-23 at 12 22 15 pm" src="https://user-images.githubusercontent.com/3933204/41812245-0d4743e0-76e5-11e8-8b56-2433d6f521a1.png"> |
