### PR TITLE
Add Website Creation API Endpoint

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,7 @@ end
 gem 'active_model_serializers', '~> 0.10.0'
 gem 'attr_encrypted', '~> 3.1', github: 'attr-encrypted/attr_encrypted'
 gem 'aws-sdk', '~> 2.10'
+gem 'daredevil', '~> 0.0.2'
 gem 'delayed_job_active_record', '~> 4.1.3'
 gem 'devise', '~> 4.4.3'
 gem 'devise_invitable', '~> 1.7'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -90,6 +90,8 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    daredevil (0.0.2)
+      rails (>= 4.2.8)
     delayed_job (4.1.5)
       activesupport (>= 3.0, < 5.3)
     delayed_job_active_record (4.1.3)
@@ -298,6 +300,7 @@ DEPENDENCIES
   aws-sdk (~> 2.10)
   byebug
   capybara (~> 2.18)
+  daredevil (~> 0.0.2)
   delayed_job_active_record (~> 4.1.3)
   devise (~> 4.4.3)
   devise_invitable (~> 1.7)

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,6 +1,8 @@
 module Api
   module V1
     class BaseController < ActionController::API
+      include Daredevil
+
       before_action(:authenticate_token!)
 
       private

--- a/app/controllers/api/v1/websites_controller.rb
+++ b/app/controllers/api/v1/websites_controller.rb
@@ -7,6 +7,25 @@ module Api
           each_serializer: WebsiteSerializer
         )
       end
+
+      def create
+        @website = Website.new(website_params)
+
+        if @website.save
+          respond_with @website, status: 201
+        else
+          respond_with @website, status: 400
+        end
+      end
+
+      private
+
+      def website_params
+        params.require(:website).permit(
+          :name, :url, :basic_auth_username, :basic_auth_password,
+          :aws_instance_id, :aws_region
+        )
+      end
     end
   end
 end

--- a/config/initializers/daredevil.rb
+++ b/config/initializers/daredevil.rb
@@ -1,0 +1,3 @@
+Daredevil.configure do |config|
+  config.responder_type = :serializers
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -20,7 +20,7 @@ Rails.application.routes.draw do
 
   namespace(:api) do
     namespace(:v1) do
-      resources(:websites, only: %w(index))
+      resources(:websites, only: %w(index create))
     end
   end
 

--- a/test/controllers/api/v1/websites_controller_test.rb
+++ b/test/controllers/api/v1/websites_controller_test.rb
@@ -28,6 +28,30 @@ module Api
           )
 
           assert_response(201)
+          assert response_json[:id].present?
+          assert response_json[:name].present?
+          assert response_json[:url].present?
+        end
+
+        test 'should post create and return errors when invalid' do
+          params = {
+            website: {
+              name: '',
+              url: 'https://proctoru.com'
+            }
+          }
+          post(
+            api_v1_websites_path,
+            params: params,
+            headers: { 'X-AUTHORIZATION-TOKEN' => token.value }
+          )
+
+          assert_response(400)
+          assert response_json[:status].present?
+          assert response_json[:message].present?
+          assert response_json[:errors].present?
+          assert_includes response_json[:message], 'Invalid Attribute'
+          assert_equal 1, response_json[:errors].size
         end
       end
 

--- a/test/controllers/api/v1/websites_controller_test.rb
+++ b/test/controllers/api/v1/websites_controller_test.rb
@@ -13,6 +13,22 @@ module Api
           )
           assert_response(200)
         end
+
+        test 'should post create' do
+          params = {
+            website: {
+              name: 'Testing Website',
+              url: 'https://proctoru.com'
+            }
+          }
+          post(
+            api_v1_websites_path,
+            params: params,
+            headers: { 'X-AUTHORIZATION-TOKEN' => token.value }
+          )
+
+          assert_response(201)
+        end
       end
 
       feature 'with an invalid Token' do
@@ -23,12 +39,42 @@ module Api
           )
           assert_response(401)
         end
+
+        test 'should not post create' do
+          params = {
+            website: {
+              name: 'Testing Website',
+              url: 'https://proctoru.com'
+            }
+          }
+
+          post(
+            api_v1_websites_path,
+            params: params,
+            headers: { 'X-AUTHORIZATION-TOKEN' => 'invalid' }
+          )
+          assert_response(401)
+        end
       end
 
       feature 'without a Token' do
         test 'should not get index' do
           get(
             api_v1_websites_path
+          )
+          assert_response(401)
+        end
+
+        test 'should not post create' do
+          params = {
+            website: {
+              name: "Testing Website",
+              url: "https://proctoru.com"
+            }
+          }
+          post(
+            api_v1_websites_path,
+            params: params,
           )
           assert_response(401)
         end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -7,6 +7,10 @@ class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods
 
   Delayed::Worker.delay_jobs = false
+
+  def response_json
+    JSON.parse(response.body, symbolize_names: true)
+  end
 end
 
 class ActionDispatch::IntegrationTest


### PR DESCRIPTION
Adds an API endpoint for website creation:

- Create an API Token
- Add that API token to the X-AUTHORIZATION-TOKEN header
- Post to http://localhost:3000/api/v1/websites with this JSON:
```
{
	"name": "Testing",
	"url": "https://google.com"
}
```

Optionally, you can also pass as JSON keys with values to set them as well. 
```
	"basic_auth_username": null,
	"basic_auth_password": null,
	"aws_instance_id": null,
	"aws_region": "us-west-2"
```

Example Success + response:

![image](https://user-images.githubusercontent.com/1741179/41812628-3ef86ab6-76ec-11e8-8465-ed49265c9cc4.png)
