### PR TITLE
Add ability to make websites inactive

### DIFF
--- a/app/controllers/api/v1/websites_controller.rb
+++ b/app/controllers/api/v1/websites_controller.rb
@@ -23,7 +23,7 @@ module Api
       def website_params
         params.require(:website).permit(
           :name, :url, :basic_auth_username, :basic_auth_password,
-          :aws_instance_id, :aws_region
+          :active, :aws_instance_id, :aws_region
         )
       end
     end

--- a/app/controllers/websites_controller.rb
+++ b/app/controllers/websites_controller.rb
@@ -5,7 +5,7 @@ class WebsitesController < ApplicationController
   before_action(:set_website, only: %w(show edit update destroy))
 
   def index
-    @websites = Website.active.paginate(params).decorate
+    @websites = Website.paginate(params).decorate
 
     respond_to do |format|
       format.html
@@ -58,7 +58,7 @@ class WebsitesController < ApplicationController
   def website_params
     params.require(:website).permit(
       :name, :url, :basic_auth_username, :basic_auth_password,
-      :aws_instance_id, :aws_region
+      :active, :aws_instance_id, :aws_region
     )
   end
 end

--- a/app/jobs/pinger_job.rb
+++ b/app/jobs/pinger_job.rb
@@ -3,6 +3,13 @@ class PingerJob < ApplicationJob
   queue_as(:default)
 
   def perform(website, retry_attempt = false)
+    return enqueue_next_job(website) unless website.active?
     Pings::Manager.new(website, retry_attempt).ping
+  end
+
+  private
+
+  def enqueue_next_job(website)
+    PingerJob.set(wait: 1.minute).perform_later(website)
   end
 end

--- a/app/jobs/pinger_job.rb
+++ b/app/jobs/pinger_job.rb
@@ -3,13 +3,6 @@ class PingerJob < ApplicationJob
   queue_as(:default)
 
   def perform(website, retry_attempt = false)
-    return enqueue_next_job(website) unless website.active?
     Pings::Manager.new(website, retry_attempt).ping
-  end
-
-  private
-
-  def enqueue_next_job(website)
-    PingerJob.set(wait: 1.minute).perform_later(website)
   end
 end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -17,9 +17,7 @@ class Website < ApplicationRecord
   before_create(:set_ssl)
   after_commit(:create_ping, on: :create)
 
-  default_scope { undeleted }
   scope(:active, -> { where(active: true) })
-  scope(:undeleted, -> { where(deleted_at: nil) })
 
   def basic_auth?
     [basic_auth_username, basic_auth_password].all?(&:present?)

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -17,8 +17,9 @@ class Website < ApplicationRecord
   before_create(:set_ssl)
   after_commit(:create_ping, on: :create)
 
-  default_scope { active }
+  default_scope { undeleted }
   scope(:active, -> { where(active: true) })
+  scope(:undeleted, -> { where(deleted_at: nil) })
 
   def basic_auth?
     [basic_auth_username, basic_auth_password].all?(&:present?)

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -44,7 +44,7 @@ class Website < ApplicationRecord
     if active?
       create_ping
     else
-      job.destroy
+      job.destroy if job.present?
     end
   end
 end

--- a/app/serializers/website_serializer.rb
+++ b/app/serializers/website_serializer.rb
@@ -1,5 +1,5 @@
 class WebsiteSerializer < ActiveModel::Serializer
-  attributes(:id, :name, :url)
+  attributes(:id, :name, :url, :active)
 
   has_many(:recent_pings, serializer: PingSerializer)
 end

--- a/app/views/websites/_form.html.erb
+++ b/app/views/websites/_form.html.erb
@@ -14,8 +14,7 @@
   </div>
 
   <div class="form-check">
-    <%= f.check_box(:active,
-    class: "form-check-input") %>
+    <%= f.check_box(:active, class: "form-check-input") %>
     <%= f.label(:active, t('.active'), class: "form-check-label") %>
     <%= error_message_on(f.object, :active) %>
   </div>

--- a/app/views/websites/_form.html.erb
+++ b/app/views/websites/_form.html.erb
@@ -13,6 +13,13 @@
     <%= error_message_on(f.object, :url) %>
   </div>
 
+  <div class="form-check">
+    <%= f.check_box(:active,
+    class: "form-check-input") %>
+    <%= f.label(:active, t('.active'), class: "form-check-label") %>
+    <%= error_message_on(f.object, :active) %>
+  </div>
+
   <div class="hr-sect"><%= t('.optional') %></div>
 
   <div class="form-group">

--- a/app/views/websites/_website.html.erb
+++ b/app/views/websites/_website.html.erb
@@ -3,7 +3,7 @@
     <div class="card-body">
       <h5 class="card-title mb-0">
         <% unless website.active? %>
-          <small class="badge badge-secondary badge-pill lh-1 float-right">Inactive</small>
+          <small class="badge badge-secondary lh-1 float-right">Inactive</small>
         <% end %>
 
         <%= website.name %>

--- a/app/views/websites/_website.html.erb
+++ b/app/views/websites/_website.html.erb
@@ -1,7 +1,13 @@
 <div class="col-lg-4 col-md-12">
   <%= link_to(website_path(website), class: "card card-link mb-3") do %>
     <div class="card-body">
-      <h5 class="card-title mb-0"><%= website.name %></h5>
+      <h5 class="card-title mb-0">
+        <% unless website.active? %>
+          <small class="badge badge-secondary badge-pill lh-1 float-right">Inactive</small>
+        <% end %>
+
+        <%= website.name %>
+      </h5>
 
       <div class="hr-sect">Recent Pings</div>
 

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -141,6 +141,7 @@ en:
       aws_region_select: Select a region
       optional: Optional
       url: URL
+      active: Active
     index:
       add: Add website
       resource: website

--- a/test/controllers/api/v1/websites_controller_test.rb
+++ b/test/controllers/api/v1/websites_controller_test.rb
@@ -18,7 +18,8 @@ module Api
           params = {
             website: {
               name: 'Testing Website',
-              url: 'https://proctoru.com'
+              url: 'https://proctoru.com',
+              active: true
             }
           }
           post(
@@ -31,6 +32,28 @@ module Api
           assert response_json[:id].present?
           assert response_json[:name].present?
           assert response_json[:url].present?
+          assert response_json[:active]
+        end
+
+        test 'should post create and create inactive' do
+          params = {
+            website: {
+              name: 'Testing Website',
+              url: 'https://proctoru.com',
+              active: false
+            }
+          }
+          post(
+            api_v1_websites_path,
+            params: params,
+            headers: { 'X-AUTHORIZATION-TOKEN' => token.value }
+          )
+
+          assert_response(201)
+          assert response_json[:id].present?
+          assert response_json[:name].present?
+          assert response_json[:url].present?
+          assert_not response_json[:active]
         end
 
         test 'should post create and return errors when invalid' do

--- a/test/controllers/websites_controller_test.rb
+++ b/test/controllers/websites_controller_test.rb
@@ -34,6 +34,15 @@ class WebsitesControllerTest < ActionDispatch::IntegrationTest
       end
     end
 
+    test 'should patch update and set website inactive' do
+      assert_no_difference('Website.count') do
+        patch(website_path(@website), params: inactive_params)
+        assert_not_nil(flash[:success])
+        assert_redirected_to(root_path)
+        assert_not @website.reload.active?
+      end
+    end
+
     test 'should post create' do
       assert_difference('Website.count') do
         post(websites_path, params: params)
@@ -102,5 +111,9 @@ class WebsitesControllerTest < ActionDispatch::IntegrationTest
         ssl: false
       }
     }
+  end
+
+  def inactive_params
+    { website: params[:website].merge({ active: 0 }) }
   end
 end

--- a/test/factories/pings.rb
+++ b/test/factories/pings.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     skip_callbacks { true }
 
     trait(:success) do
-      status(1)
+      status { 1 }
     end
 
     trait(:fail) do
-      status(0)
+      status { 0 }
     end
   end
 end

--- a/test/factories/settings.rb
+++ b/test/factories/settings.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :setting do
-    aws_key('aws_key')
-    aws_secret('aws_secret')
-    slack_url('http://127.0.0.1/slack')
+    aws_key { 'aws_key' }
+    aws_secret { 'aws_secret' }
+    slack_url { 'http://127.0.0.1/slack' }
   end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "doe.john@#{n}.com" }
-    password('password')
-    confirmed_at(Time.zone.now)
+    password { 'password' }
+    confirmed_at { Time.zone.now }
 
     trait(:unconfirmed) do
-      confirmed_at(nil)
+      confirmed_at { nil }
     end
   end
 end

--- a/test/factories/websites.rb
+++ b/test/factories/websites.rb
@@ -2,17 +2,17 @@ FactoryBot.define do
   factory :website do
     sequence(:name) { |n| "Website #{n}" }
     sequence(:url) { |n| "http://#{n}.proctoru.com" }
-    ssl(false)
-    active(true)
-    rebooting(false)
+    ssl { false }
+    active { true }
+    rebooting { false }
 
     trait(:with_basic_auth) do
-      basic_auth_username('username')
-      basic_auth_password('password')
+      basic_auth_username {'username' }
+      basic_auth_password { 'password' }
     end
 
     trait(:inactive) do
-      active(false)
+      active { false }
     end
 
     factory :website_with_ping do


### PR DESCRIPTION
We needed a way to inactivate websites for when we need to do
testing/blue/green deploys.

Fixes #145

When a website is inactivated:
- The PingerJob will re-enqueue in 1 minute
- This was the easy way out rather than getting into callback-hell.

Make a website inactive by editing it in the views.

Adds support to the Website Creation API/Form to create inactive
websites.

Makes a change to the Websites views to allow it to show inactive websites, previously this was only active websites though there was no way to set active to false without using the Rails console.

Currently there is no support yet for updating existing websites via the
API.

Zoomed out view of the new-form:
![image](https://user-images.githubusercontent.com/1741179/42013232-f8c5abac-7a61-11e8-8a64-31b443d4fdc8.png)


