### PR TITLE
Use delete_all to destroy pings

### DIFF
--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -4,7 +4,7 @@ class Website < ApplicationRecord
 
   VALID_URL_REGEX = /\A#{URI::regexp(['http', 'https'])}\z/
 
-  has_many :pings, dependent: :destroy
+  has_many :pings, dependent: :delete_all
   has_many :recent_pings, -> { limit(5) }, class_name: 'Ping'
   has_many :daily_pings, -> { limit(1_440) }, class_name: 'Ping'
   has_many :monthly_pings, -> { limit(43_800) }, class_name: 'Ping'


### PR DESCRIPTION
Using delete_all will delete pings faster when you destroy a website, esp when there are thousands of pings. 