### PR TITLE
Improve page performance on websites#show

### DIFF
--- a/app/controllers/websites_controller.rb
+++ b/app/controllers/websites_controller.rb
@@ -29,7 +29,7 @@ class WebsitesController < ApplicationController
   end
 
   def show
-    @pings = @website.monthly_pings.paginate(params).decorate
+    @pings = @website.paginatable_pings.paginate(params).decorate
   end
 
   def edit; end

--- a/app/models/website.rb
+++ b/app/models/website.rb
@@ -7,7 +7,9 @@ class Website < ApplicationRecord
   has_many :pings, dependent: :destroy
   has_many :recent_pings, -> { limit(5) }, class_name: 'Ping'
   has_many :daily_pings, -> { limit(1_440) }, class_name: 'Ping'
-  has_many :monthly_pings, -> { limit(43_800) }, class_name: 'Ping'
+
+  # Only query the max number from pagination.
+  has_many :paginatable_pings, -> { limit(360) }, class_name: 'Ping'
 
   validates(:name, presence: true)
   validates(:url, presence: true, format: { with: VALID_URL_REGEX })


### PR DESCRIPTION
Since we only show 360 pings on the websites#show page (due to a max
page of 20 with 18 pings per page), there is no need to query more than
360 pings.

Resolves https://github.com/ProctorU/storm/issues/152.