### PR TITLE
Fix mocha integration and upgrade mocha from v1.4.0 to v1.6.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'webpacker', '~> 3.5'
 group :test do
   gem 'minitest-rails-capybara'
   gem 'minitest-ci'
-  gem 'mocha', '~> 1.5'
+  gem 'mocha', '~> 1.6'
   gem 'vcr', '~> 4.0'
   gem 'webmock', '~> 3.4'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -30,7 +30,7 @@ gem 'webpacker', '~> 3.5'
 group :test do
   gem 'minitest-rails-capybara'
   gem 'minitest-ci'
-  gem 'mocha', '~> 1.4'
+  gem 'mocha', '~> 1.5'
   gem 'vcr', '~> 4.0'
   gem 'webmock', '~> 3.4'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
       minitest-capybara (~> 0.8)
       minitest-metadata (~> 0.6)
       minitest-rails (~> 3.0)
-    mocha (1.4.0)
+    mocha (1.5.0)
       metaclass (~> 0.0.1)
     nio4r (2.3.0)
     nokogiri (1.8.4)
@@ -312,7 +312,7 @@ DEPENDENCIES
   local_time (~> 2.0)
   minitest-ci
   minitest-rails-capybara
-  mocha (~> 1.4)
+  mocha (~> 1.5)
   pg (~> 0.18)
   puma (~> 3.12)
   rack-cors (~> 1.0, >= 1.0.2)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -179,7 +179,7 @@ GEM
       minitest-capybara (~> 0.8)
       minitest-metadata (~> 0.6)
       minitest-rails (~> 3.0)
-    mocha (1.5.0)
+    mocha (1.6.0)
       metaclass (~> 0.0.1)
     nio4r (2.3.0)
     nokogiri (1.8.4)
@@ -312,7 +312,7 @@ DEPENDENCIES
   local_time (~> 2.0)
   minitest-ci
   minitest-rails-capybara
-  mocha (~> 1.5)
+  mocha (~> 1.6)
   pg (~> 0.18)
   puma (~> 3.12)
   rack-cors (~> 1.0, >= 1.0.2)

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,7 +1,7 @@
 require File.expand_path('../../config/environment', __FILE__)
 require 'rails/test_help'
 require 'minitest/rails/capybara'
-require 'mocha/test_unit'
+require 'mocha/minitest'
 
 class ActiveSupport::TestCase
   include FactoryBot::Syntax::Methods


### PR DESCRIPTION
I'm one of the maintainers of [mocha](https://github.com/freerange/mocha) and I recently noticed that [the Dependabot upgrade from v1.4.0 to v1.5.0](https://github.com/ProctorU/storm/pull/113) resulted in [a failing CI build](https://circleci.com/gh/ProctorU/storm/482) and so I did a bit of investigation. This PR fixes the integration with mocha and upgrades to the latest version of mocha which is now v1.6.0.