### PR TITLE
Add secondary slack url for secondary notifications

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -19,7 +19,9 @@ class SettingsController < ApplicationController
   private
 
   def setting_params
-    params.require(:setting).permit(:aws_key, :aws_secret, :slack_url)
+    params.require(:setting).permit(
+      :aws_key, :aws_secret, :slack_url, :secondary_slack_url
+    )
   end
 
   def create_settings

--- a/app/services/notifiers/services/slack_service.rb
+++ b/app/services/notifiers/services/slack_service.rb
@@ -14,6 +14,7 @@ module Notifiers
       def notify!
         return unless enabled?
         notifier.ping(message, icon_url: icon_url)
+        secondary_notifier.ping(message, icon_url: icon_url) if secondary_slack_url.present?
       end
 
       private
@@ -26,8 +27,16 @@ module Notifiers
         @slack_url ||= Setting.global.slack_url
       end
 
+      def secondary_slack_url
+        @secondary_slack_url ||= Setting.global.secondary_slack_url
+      end
+
       def notifier
         Slack::Notifier.new(slack_url, username: bot_username)
+      end
+
+      def secondary_notifier
+        Slack::Notifier.new(secondary_slack_url, username: bot_username)
       end
 
       def icon_url

--- a/app/views/settings/_form.html.erb
+++ b/app/views/settings/_form.html.erb
@@ -12,6 +12,18 @@
     </p>
   </div>
 
+  <div class="form-group">
+    <%= f.label :secondary_slack_url, t('.labels.secondary_slack_url') %>
+    <%= f.text_field :secondary_slack_url, class: "form-control" %>
+    <%= error_message_on(f.object, :secondary_slack_url) %>
+
+    <p class="form-text text-muted">
+      <small>
+        <%= t('.secondary_slack_instructions') %>
+      </small>
+    </p>
+  </div>
+
   <div class="hr-sect"><%= t('.aws_section') %></div>
 
   <small class="d-block mb-3 text-muted"><%= t('.aws_info') %></small>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -66,10 +66,13 @@ en:
       slack_action: here
       slack_instructions: >
         Instructions for finding your Slack URL can be found
+      secondary_slack_instructions: >
+        You can add a second Slack URL to notify an additional Slack channel. This is optional.
       labels:
         aws_key: AWS Key
         aws_secret: AWS Secret
         slack_url: Slack URL for notifications
+        secondary_slack_url: Additional Slack URL
     update:
       success: Your settings have been successfully updated.
   shared:

--- a/db/migrate/20190124043444_add_secondary_slack_url_to_settings.rb
+++ b/db/migrate/20190124043444_add_secondary_slack_url_to_settings.rb
@@ -1,0 +1,5 @@
+class AddSecondarySlackUrlToSettings < ActiveRecord::Migration[5.2]
+  def change
+    add_column :settings, :secondary_slack_url, :string
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180713023802) do
+ActiveRecord::Schema.define(version: 2019_01_24_043444) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -49,6 +49,7 @@ ActiveRecord::Schema.define(version: 20180713023802) do
     t.string "encrypted_aws_secret_iv"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.string "secondary_slack_url"
   end
 
   create_table "tokens", force: :cascade do |t|

--- a/test/factories/pings.rb
+++ b/test/factories/pings.rb
@@ -5,11 +5,11 @@ FactoryBot.define do
     skip_callbacks { true }
 
     trait(:success) do
-      status(1)
+      status { 1 }
     end
 
     trait(:fail) do
-      status(0)
+      status { 0 }
     end
   end
 end

--- a/test/factories/settings.rb
+++ b/test/factories/settings.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :setting do
-    aws_key('aws_key')
-    aws_secret('aws_secret')
-    slack_url('http://127.0.0.1/slack')
+    aws_key { 'aws_key' }
+    aws_secret { 'aws_secret' }
+    slack_url { 'http://127.0.0.1/slack' }
   end
 
   trait(:with_secondary_slack_url) do
-    secondary_slack_url('http://127.0.0.1/slack')
+    secondary_slack_url { 'http://127.0.0.1/slack' }
   end
 end

--- a/test/factories/settings.rb
+++ b/test/factories/settings.rb
@@ -4,4 +4,8 @@ FactoryBot.define do
     aws_secret('aws_secret')
     slack_url('http://127.0.0.1/slack')
   end
+
+  trait(:with_secondary_slack_url) do
+    secondary_slack_url('http://127.0.0.1/slack')
+  end
 end

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -1,11 +1,11 @@
 FactoryBot.define do
   factory :user do
     sequence(:email) { |n| "doe.john@#{n}.com" }
-    password('password')
-    confirmed_at(Time.zone.now)
+    password { 'password' }
+    confirmed_at { Time.zone.now }
 
     trait(:unconfirmed) do
-      confirmed_at(nil)
+      confirmed_at { nil }
     end
   end
 end

--- a/test/factories/websites.rb
+++ b/test/factories/websites.rb
@@ -2,17 +2,17 @@ FactoryBot.define do
   factory :website do
     sequence(:name) { |n| "Website #{n}" }
     sequence(:url) { |n| "http://#{n}.proctoru.com" }
-    ssl(false)
-    active(true)
-    rebooting(false)
+    ssl { false }
+    active { true }
+    rebooting { false }
 
     trait(:with_basic_auth) do
-      basic_auth_username('username')
-      basic_auth_password('password')
+      basic_auth_username { 'username' }
+      basic_auth_password { 'password' }
     end
 
     trait(:inactive) do
-      active(false)
+      active { false }
     end
 
     factory :website_with_ping do


### PR DESCRIPTION
Fixes #83 

We wanted to add support for a second Slack channel for notifications to go to. 