### PR TITLE
Add daemons gem

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -12,6 +12,7 @@ gem 'active_model_serializers', '~> 0.10.9'
 gem 'attr_encrypted', '~> 3.1', github: 'attr-encrypted/attr_encrypted'
 gem 'aws-sdk', '~> 2.10'
 gem 'bootsnap', '>= 1.1.0', require: false
+gem 'daemons', '~> 1.3'
 gem 'daredevil', '~> 0.0.2'
 gem 'delayed_job_active_record', '~> 4.1.3'
 gem 'devise', '~> 4.6.2'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -104,6 +104,7 @@ GEM
     crack (0.4.3)
       safe_yaml (~> 1.0.0)
     crass (1.0.4)
+    daemons (1.3.1)
     daredevil (0.0.2)
       rails (>= 4.2.8)
     delayed_job (4.1.5)
@@ -323,6 +324,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.18)
   chromedriver-helper
+  daemons (~> 1.3)
   daredevil (~> 0.0.2)
   delayed_job_active_record (~> 4.1.3)
   devise (~> 4.6.2)


### PR DESCRIPTION
This gem is required in order to use "bin/delayed_job start" which spawns and works the jobs in the background whereas "rake jobs:work" runs in the foreground.

For more on this, [see the delayed_job README](https://github.com/collectiveidea/delayed_job#running-jobs).