### PR TITLE
Implement ability to be notified by email

### DIFF
--- a/app/controllers/settings_controller.rb
+++ b/app/controllers/settings_controller.rb
@@ -21,7 +21,7 @@ class SettingsController < ApplicationController
   private
 
   def setting_params
-    params.require(:setting).permit(:aws_key, :aws_secret, :slack_url)
+    params.require(:setting).permit(:aws_key, :aws_secret, :slack_url, :email_address)
   end
 
   def create_settings

--- a/app/mailers/application_mailer.rb
+++ b/app/mailers/application_mailer.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
 class ApplicationMailer < ActionMailer::Base
-  default from: 'from@example.com'
+  default from: ENV['STORM_MAIL_FROM']
   layout 'mailer'
 end

--- a/app/mailers/notification_mailer.rb
+++ b/app/mailers/notification_mailer.rb
@@ -1,0 +1,11 @@
+# frozen_string_literal: true
+
+class NotificationMailer < ApplicationMailer
+  def notify(email_address, subject, message)
+    @subject = subject
+    @message = message
+    mail(to: email_address, subject: subject) do |format|
+      format.text { render plain: message }
+    end
+  end
+end

--- a/app/services/notifiers/ping_notifier.rb
+++ b/app/services/notifiers/ping_notifier.rb
@@ -13,6 +13,7 @@ module Notifiers
     def notify!
       return unless can_notify?
       Notifiers::Services::SlackService.new(message).notify!
+      Notifiers::Services::MailerService.new(message).notify!
     end
 
     private

--- a/app/services/notifiers/services/mailer_service.rb
+++ b/app/services/notifiers/services/mailer_service.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+module Notifiers
+  module Services
+    # MailerService
+    #
+    # Send messages via Rails mailers.
+    class MailerService
+      attr_reader(:message)
+
+      def initialize(message)
+        @message = message
+      end
+
+      def notify!
+        return unless enabled?
+        NotificationMailer.notify(email_address, subject, message).deliver_later
+      end
+
+      private
+
+      def enabled?
+        email_address.present?
+      end
+
+      def email_address
+        @email_address ||= Setting.global.email_address
+      end
+
+      def subject
+        @subject ||= I18n.t('notifiers.mailer_service.subject')
+      end
+    end
+  end
+end

--- a/app/views/settings/_form.html.erb
+++ b/app/views/settings/_form.html.erb
@@ -12,6 +12,12 @@
     </p>
   </div>
 
+  <div class="form-group">
+    <%= f.label :email_address, t('.labels.email_address') %>
+    <%= f.text_field :email_address, autofocus: true, class: "form-control" %>
+    <%= error_message_on(f.object, :email_address) %>
+  </div>
+
   <div class="hr-sect"><%= t('.aws_section') %></div>
 
   <small class="d-block mb-3 text-muted"><%= t('.aws_info') %></small>

--- a/config/initializers/mail.rb
+++ b/config/initializers/mail.rb
@@ -1,0 +1,9 @@
+ActionMailer::Base.delivery_method = :smtp
+
+ActionMailer::Base.smtp_settings = {
+  address: ENV['STORM_SMTP_ADDRESS'],
+  port: (ENV['STORM_SMTP_PORT'] || 25),
+  user_name: ENV['STORM_SMTP_USERNAME'],
+  password: ENV['STORM_SMTP_PASSWORD'],
+  domain: ENV['STORM_SMTP_DOMAIN']  
+}

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -70,6 +70,7 @@ en:
         aws_key: AWS Key
         aws_secret: AWS Secret
         slack_url: Slack URL for notifications
+        email_address: Email address for notifications
     update:
       success: Your settings have been successfully updated.
   shared:
@@ -219,3 +220,6 @@ en:
       destroy_link: Delete user
       invitation_link: Invitation Link
       reset_password: Reset password
+  notifiers:
+    mailer_service:
+      subject: Storm Notification

--- a/db/migrate/20191010200241_add_email_address_to_settings.rb
+++ b/db/migrate/20191010200241_add_email_address_to_settings.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class AddEmailAddressToSettings < ActiveRecord::Migration[5.2]
+  def change
+    add_column(:settings, :email_address, :text)
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -12,7 +12,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20180713023802) do
+ActiveRecord::Schema.define(version: 2019_10_10_200241) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -51,6 +51,7 @@ ActiveRecord::Schema.define(version: 20180713023802) do
     t.string "encrypted_aws_secret_iv"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.text "email_address"
   end
 
   create_table "tokens", force: :cascade do |t|

--- a/test/mailers/notification_mailer_test.rb
+++ b/test/mailers/notification_mailer_test.rb
@@ -1,0 +1,15 @@
+require "test_helper"
+
+class NotificationMailerTest < ActionMailer::TestCase
+  test "notify" do
+    ENV['STORM_MAIL_FROM'] = 'sender@test.com'
+    email = NotificationMailer.notify('recipient@test.com', 'subject', 'message').deliver_now
+
+    assert_not ActionMailer::Base.deliveries.empty?
+
+    assert_equal ['sender@test.com'], email.from
+    assert_equal ['recipient@test.com'], email.to
+    assert_equal 'subject', email.subject
+    assert_equal 'message', email.body.to_s
+  end
+end

--- a/test/services/notifiers/services/mailer_service_test.rb
+++ b/test/services/notifiers/services/mailer_service_test.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+require('test_helper')
+
+module Notifiers
+  module Services
+    # MailerServiceTest
+    class MailerServiceTest < ActiveSupport::TestCase
+      test 'notify! without an email address present' do
+        create(:setting, email_address: nil)
+        instance = Notifiers::Services::MailerService.new('msg')
+
+        assert_not(instance.send(:enabled?))
+      end
+    end
+  end
+end


### PR DESCRIPTION
For those like me who don't use Slack, this PR implements an alternative notification method by good ole email or (when using a third-party email to SMS bridge) short messages.

Please note that a few environment variables have to be defined in order for this to work:

* `STORM_MAIL_FROM` – sender email address of the notifications
* `STORM_SMTP_ADDRESS` – the SMTP server to use
* `STORM_SMTP_PORT`– the SMTP port to use (default: 25)
* `STORM_SMTP_USERNAME` – optional username for SMTP auth
* `STORM_SMTP_PASSWORD` – optional password for SMTP auth
* `STORM_SMTP_DOMAIN` – optional domain name used for HELO/EHLO

The recipient of the mail notifications has to be set by use of the settings view of the app.
