### PR TITLE
Fix increment of Ping#retry_count

### DIFF
--- a/app/services/pings/manager.rb
+++ b/app/services/pings/manager.rb
@@ -35,7 +35,7 @@ module Pings
       ping.update_columns(ping_attributes(website.url))
       return enqueue_next_ping(ping) if successful?(ping.reload)
 
-      ping.update_column(:retry_count, ping.retry_count + 1)
+      ping.update_column(:retry_count, (ping.retry_count || 0) + 1)
       PingerJob.set(wait: 10.seconds).perform_later(website, true)
       ping
     end


### PR DESCRIPTION
While working on #282, I've noticed errors in the Delayed::Job queue which originate from this LOC trying to add 1 to nil. There are of course several ways to solve this. My first choice would have been a default value of 0 enforced by the db schema, but since there are no defaults elsewhere, I figured you'd rather prefer a solution on the application layer.